### PR TITLE
検索パターン削除モーダルのリダイレクト先を「/search/patterns」に変更し、検索パターンリストの新規作成リンクを「/search/execute?patternId=new」に修正。

### DIFF
--- a/app/(main)/search/execute/components/search-pattern-delete-modal.tsx
+++ b/app/(main)/search/execute/components/search-pattern-delete-modal.tsx
@@ -43,7 +43,7 @@ export function SearchPatternDeleteModal({
 
       if (result.success) {
         toast.success("検索パターンを削除しました");
-        router.push("/search");
+        router.push("/search/patterns");
       }
     } catch (error) {
       console.error("削除エラー:", error);
@@ -65,16 +65,16 @@ export function SearchPatternDeleteModal({
         </AlertDialogHeader>
 
         <AlertDialogFooter>
-          <Button 
-            type="button" 
-            variant="outline" 
+          <Button
+            type="button"
+            variant="outline"
             onClick={onClose}
             disabled={isDeleting}
           >
             キャンセル
           </Button>
-          <Button 
-            variant="destructive" 
+          <Button
+            variant="destructive"
             onClick={handleDelete}
             disabled={isDeleting}
           >

--- a/app/(main)/search/patterns/list.tsx
+++ b/app/(main)/search/patterns/list.tsx
@@ -68,7 +68,7 @@ export default async function SearchPatternList({
     return (
       <div className="text-center py-12">
         <p className="text-muted-foreground">検索パターンがまだありません</p>
-        <Link href="/execute?patternId=new">
+        <Link href="/search/execute?patternId=new">
           <Button className="mt-4">最初の検索を開始</Button>
         </Link>
       </div>


### PR DESCRIPTION
最初の検索を開始　をおすとへんなとことぶぢゃないか！！！！ #8

を修正しました。